### PR TITLE
2.6.5 사용시 build.gradle 오류

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.6.5'
+	id 'org.springframework.boot' version '2.6.3'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }


### PR DESCRIPTION
스프링부트 버전 2.6.5 사용시
[ A problem occurred evaluating root project 'forrest'.  ] 오류발생
2.6.5 -> 2.6.3 변경 후 해결